### PR TITLE
[WIP]posts-delite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     arel (9.0.0)
     bcrypt (3.1.15)
     bindex (0.8.1)
-    bootsnap (1.4.7)
+    bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -100,7 +100,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
     devise (4.7.2)
       bcrypt (~> 3.0)

--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -1,29 +1,8 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
-    $(".option-btn").on("click", function(){
+    $(".option-btn-post").on("click", function(){
       $(".gray-back").fadeIn("show");
       $(".option-menu").fadeIn("show");
-    })
-    $(".gray-back").on("click", function(){
-      $(".gray-back").fadeOut("show");
-      $(".option-menu").fadeOut("show");
-      $(".follow-cancel-window").fadeOut("show")
-    })
-    $(".cancel-btn").on("click", function(){
-      $(".gray-back").fadeOut("show");
-      $(".option-menu").fadeOut("show");
-    })
-    $(".option-btn-other").on("click", function(){
-      $(".gray-back").fadeIn("show");
-      $(".option-menu").fadeIn("show");
-    })
-    $(".follow-cancel-btn").on("click", function(){
-      $(".gray-back").fadeIn("show");
-      $(".follow-cancel-window").fadeIn("show");
-    })
-    $(".cancel-window").on("click", function(){
-      $(".gray-back").fadeOut("show");
-      $(".follow-cancel-window").fadeOut("show");
     })
   });
 });

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -578,17 +578,6 @@
 
 
 // モーダルウィンドウ
-
-.option-btn{
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  outline: none;
-  padding: 0;
-  appearance: none;
-  font-size: 26px;
-  color: $font-basic;
-}
 .gray-back{
   position: fixed;
   top: 0;
@@ -599,6 +588,7 @@
   width: 100%;
   background-color: #000000a6;
   display: none;
+
 }
 .option-menu{
   position: fixed;
@@ -608,46 +598,70 @@
   border-radius: 10px;
   background-color: $background;
   display: none;
+
   z-index: 15;
-  ul{
-    .option-list{
-      border-bottom: solid 1px $light-gray;
-      line-height: 80px;
-      text-align: center;
-      a{
-        text-decoration: none;
-        color: $font-basic;
-      }
-      &__follow {
-        
-        border-bottom: solid 1px $light-gray;
-        line-height: 80px;
-        text-align: center;
-        a {
-          text-decoration: none;
-          color: red;
-        }
-      }
-    }
-    .option-list-bottom{
-      line-height: 80px;
-      text-align: center;
-      button{
-        font-size: 16px;
-        color: $font-basic;
-        background-color: transparent;
-        border: none;
-        cursor: pointer;
-        outline: none;
-        padding: 0;
-        appearance: none;
-      }
-    }
+}
+
+.option-listc-delete {
+  border-bottom: solid 1px $light-gray;
+  line-height: 80px;
+  text-align: center;
+  a{
+    text-decoration: none;
+    color: red;
+  }
+}
+.option-list-edit {
+  border-bottom: solid 1px $light-gray;
+  line-height: 80px;
+  text-align: center;
+  a{
+    text-decoration: none;
+    color: $font-basic;
+  }
+}
+.option-list-follow-cancel {
+  border-bottom: solid 1px $light-gray;
+  line-height: 80px;
+  text-align: center;
+  a {
+    text-decoration: none;
+    color: red;
+  }
+}
+.option-post {
+  border-bottom: solid 1px $light-gray;
+  line-height: 80px;
+  text-align: center;
+  a{
+    text-decoration: none;
+    color: $font-basic;
+  }
+}
+.option-list-bottom{
+  line-height: 80px;
+  text-align: center;
+  button{
+    font-size: 16px;
+    color: $font-basic;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+    appearance: none;
   }
 }
 
-
-
+.option-btn-post {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
+  appearance: none;
+  margin-left: 20px;
+}
 
 
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -148,8 +148,8 @@
   }
   &__content {
     padding:  0 16px;
-    width: 582px;
-    height: 22px;
+    width: 100%;
+    height: 100%;
     color: #262626;
     font-size: 14px;
     line-height: 18px;
@@ -1030,3 +1030,19 @@
   }
 }
 
+
+// edit
+.edit-content {
+  color: #262626;
+  font-size: 14px;
+  height: 50%;
+  line-height: 18px;
+  width: 100%;
+  border: 0px;
+  outline: none;
+  resize: none;
+}
+
+.edit-content::-webkit-scrollbar {
+  display: none;
+}

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -2,7 +2,7 @@
   height: 100px;
   width: 100%;
   background-color: $background;
-  padding-top: 30px;
+  padding-top: 30zpx;
   .footer-inner{
     width: 1000px;
     margin: 0 auto;

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -110,6 +110,7 @@
   box-shadow: 0 0 4px 4px rgba(199, 199, 199, 0.4);
   border-radius: 6px;
   display: none;
+  z-index: 100;
   .notification-list{
     a{
       height: 36px;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,6 +29,13 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def update
+    post = Post.find(params[:id])
+    post.update(post_params)
+    redirect_to root_path
+  end
+
+
   def destroy
     post = Post.find(params[:id])
     post.destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :move_to_index, only: [:new, :create, :edit, :update]
-  before_action :post_item, except: [:index, :new, :create]
+  # before_action :post_item, except: [:index, :new, :create]
 
   def index
     @posts = Post.includes(:user).order('created_at DESC')
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    # @post = Post.find_by(id:params[:id])
+    @post = Post.find(params[:id])
   end
   
   def create
@@ -28,6 +28,13 @@ class PostsController < ApplicationController
   def edit
     @post = Post.find(params[:id])
   end
+
+  def destroy
+    post = Post.find(params[:id])
+    post.destroy
+    redirect_to root_path
+  end
+
 
   private
   def post_params

--- a/app/views/posts/_edit-main.html.haml
+++ b/app/views/posts/_edit-main.html.haml
@@ -1,0 +1,59 @@
+.post__contents
+  .post__contents__container
+    = form_with model: @post, local: true do |f|
+      .header__post
+        .header__post__back
+          =link_to root_path do
+            =icon('fas fa-chevron-left', class: "header-back-icon")
+        .header__post__newpost
+          基本データを編集する
+        = f.submit "完了", class: 'header__post__submit'
+
+      .posts__show
+        .posts__show__main
+          .posts__show__main__body
+            .posts__show__main__body__contents
+              .posts__show__main__body__contents__image
+                = image_tag @post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "436x436"
+              .posts__show__main__body__contents__side
+                .posts__show__main__body__contents__side__header
+                  .posts__show__main__body__contents__side__header__icon
+                    = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
+                  .posts__show__main__body__contents__side__header__name
+                    =link_to exhibition_path, class: "show-name" do
+                      = @post.user.username
+                
+                            
+                .posts__show__main__body__contents__side__right
+                  .posts__show__main__body__contents__side__right__main
+                    .posts__show__main__body__contents__side__right__main__icon
+                      = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
+                    .posts__show__main__body__contents__side__right__main__name
+                      =link_to exhibition_path, class: "show-name" do
+                        = @post.user.username
+                      .posts__show__main__body__contents__side__right__main__name__text
+                        =f.text_area :content, class: "edit-content"
+                        
+                  .posts__show__main__body__contents__side__right__footer
+                    .posts__show__main__body__contents__side__right__footer__icon
+                      = icon('far fa-heart',  class: "main-show-icon")
+                    .posts__show__main__body__contents__side__right__footer__icon
+                      = icon('far fa-comment',  class: "main-show-icon")
+                    .posts__show__main__body__contents__side__right__footer__icon
+                      = icon('far fa-share-square',  class: "main-show-icon")
+                  .posts__show__main__body__contents__side__right__like
+                    .posts__show__main__body__contents__side__right__like__image
+                      = image_tag src="/BackgroundHomeSummer.jpg", size: "25x25", class: "show-header-icon"
+                    .posts__show__main__body__contents__side__right__like__fab
+                      フォロワー、他50人が「いいね！」しました
+
+                  .posts__show__main__body__contents__side__right__time
+                    %time(datetime="#{@post.created_at}")= time_ago_in_words(@post.created_at)
+                    
+                  = form_with model: @posts, local: true do |f|
+                    .posts__show__main__body__contents__side__right__comment
+                      .posts__show__main__body__contents__side__right__comment__box
+
+                        = f.text_area :content, class: "posts__show__main__body__contents__side__right__comment__box__add", placeholder: 'コメントを追加...'
+                        = f.submit "投稿する", class: 'posts__show__main__body__contents__side__right__comment__box__submit'
+                  

--- a/app/views/posts/_mainside-rightber.html.haml
+++ b/app/views/posts/_mainside-rightber.html.haml
@@ -5,9 +5,9 @@
         = image_tag src="/BackgroundHomeSummer.jpg", size: "56x56", class: "tops-icon"
       .mainside__profile__line__text 
         .mainside__profile__line__text__username
-          ユーザーネーム
+          = current_user.username
         .mainside__profile__line__text__nickname
-          ニックネーム
+          = current_user.nickname
   
   .mainside__recommended
     .mainside__recommended__side

--- a/app/views/posts/_posts-image.html.haml
+++ b/app/views/posts/_posts-image.html.haml
@@ -8,7 +8,7 @@
         .mainber__header__head__name-place__name
           = post.user.username
         .mainber__header__head__name-place__place
-          場所
+          = post.user.nickname
   %span.mainber__images
     =link_to post_path(post) do
       = image_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614x614"

--- a/app/views/posts/_posts-image.html.haml
+++ b/app/views/posts/_posts-image.html.haml
@@ -9,24 +9,9 @@
           = post.user.username
         .mainber__header__head__name-place__place
           場所
-      .show-header-details-top__option
-        %button.option-btn
-          = icon('fas fa-ellipsis-h',  class: "mainber__headright__btn--icon")
-
-        .gray-back
-        .option-menu
-          %ul
-            %li.option-list__follow
-              =link_to "#" do
-                フォローをやめる
-            %li.option-list
-              =link_to  "#" do
-                投稿へ移動
-            %li.option-list-bottom
-              %button.cancel-btn キャンセル
   %span.mainber__images
-    -# = image_tag src="/BackgroundHomeSummer.jpg", class: "main-new-arrival__product--image--first", size: "614x614"
-    = image_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614x614"
+    =link_to post_path(post) do
+      = image_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614x614"
   %section.mainber__icon
     %span.mainber__icon__heart
       = icon('far fa-heart',  class: "mainber__icon__heart__btn--icon")

--- a/app/views/posts/_show-main.html.haml
+++ b/app/views/posts/_show-main.html.haml
@@ -3,41 +3,49 @@
     .posts__show__main__body
       .posts__show__main__body__contents
         .posts__show__main__body__contents__image
-          = image_tag src="/BackgroundHomeSummer.jpg", size: "436x436", class: "show-icon"
+          = image_tag @post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "436x436"
         .posts__show__main__body__contents__side
           .posts__show__main__body__contents__side__header
             .posts__show__main__body__contents__side__header__icon
               = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
             .posts__show__main__body__contents__side__header__name
               =link_to exhibition_path, class: "show-name" do
-                username
+                = current_user.username
             .posts__show__main__body__contents__side__header__fab
-              = icon('fas fa-ellipsis-h',  class: "show-header-icon")
+              %button.option-btn-post
+                = icon('fas fa-ellipsis-h',  class: "show-header-icon")
+              .gray-back
+                -if user_signed_in? && current_user.id == @post.user_id
+                  .option-menu
+                    %ul
+                      %li.option-listc-delete
+                        =link_to '削除', "/posts/#{@post.id}", method: :delete
+                        
+                      %li.option-list-edit
+                        =link_to  "#" do
+                          編集
+                      %li.option-list-bottom
+                        %button.cancel-btn キャンセル
+                -else
+                  .option-menu     
+                    %ul
+                      %li.option-list-follow-cancel
+                        =link_to "#" do
+                          フォローをやめる
+                      %li.option-post
+                        =link_to  "#" do
+                          投稿へ移動
+                      %li.option-list-bottom
+                        %button.cancel-btn キャンセル
           .posts__show__main__body__contents__side__right
             .posts__show__main__body__contents__side__right__main
               .posts__show__main__body__contents__side__right__main__icon
                 = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
               .posts__show__main__body__contents__side__right__main__name
                 =link_to exhibition_path, class: "show-name" do
-                  username
+                  = current_user.username
                 .posts__show__main__body__contents__side__right__main__name__text
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
-                  %br
-                  photephotephotephotephotephotephotephote
+                  = @post.content
                   
             .posts__show__main__body__contents__side__right__footer
               .posts__show__main__body__contents__side__right__footer__icon
@@ -53,9 +61,9 @@
                 フォロワー、他50人が「いいね！」しました
 
             .posts__show__main__body__contents__side__right__time
-              10時間前
+              %time(datetime="#{@post.created_at}")= time_ago_in_words(@post.created_at)
               
-            = form_with model: @post, local: true do |f|
+            = form_with model: @posts, local: true do |f|
               .posts__show__main__body__contents__side__right__comment
                 .posts__show__main__body__contents__side__right__comment__box
 

--- a/app/views/posts/_show-main.html.haml
+++ b/app/views/posts/_show-main.html.haml
@@ -10,7 +10,7 @@
               = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
             .posts__show__main__body__contents__side__header__name
               =link_to exhibition_path, class: "show-name" do
-                = current_user.username
+                = @post.user.username
             .posts__show__main__body__contents__side__header__fab
               %button.option-btn-post
                 = icon('fas fa-ellipsis-h',  class: "show-header-icon")
@@ -43,7 +43,7 @@
                 = image_tag src="/BackgroundHomeSummer.jpg", size: "32x32", class: "show-header-icon"
               .posts__show__main__body__contents__side__right__main__name
                 =link_to exhibition_path, class: "show-name" do
-                  = current_user.username
+                  = @post.user.username
                 .posts__show__main__body__contents__side__right__main__name__text
                   = @post.content
                   

--- a/app/views/posts/_show-main.html.haml
+++ b/app/views/posts/_show-main.html.haml
@@ -22,8 +22,9 @@
                         =link_to '削除', "/posts/#{@post.id}", method: :delete
                         
                       %li.option-list-edit
-                        =link_to  "#" do
-                          編集
+                        %div{"data-turbolinks" => "false"}
+                          =link_to edit_post_path do
+                            編集
                       %li.option-list-bottom
                         %button.cancel-btn キャンセル
                 -else

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -1,0 +1,2 @@
+=render "edit-main"
+=render "shared/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   resources :messages, only: [:index, :show]
 
-  resources :posts, only: [:index, :new, :create, :show]
+  resources :posts, only: [:index, :new, :create, :show, :destroy]
   resources :tags, only: [:new]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   resources :messages, only: [:index, :show]
 
-  resources :posts, only: [:index, :new, :create, :show, :destroy]
+  resources :posts, only: [:index, :new, :create, :show ,:edit, :update, :destroy]
   resources :tags, only: [:new]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
What
削除機能の実装
showページの実装


Why
・詳細ページで投稿が削除できるようになった。
　※トップページでモーダルウィンドウの複数表示ができない為。
　（クラスがかぶる為、投稿をするたびにモーダルウィンドウを開くと、CSSが重複してしまう）

下記の投稿を削除する
https://gyazo.com/88523582ca4ce9f3ca89051757f92045

詳細ページに飛ぶ
https://gyazo.com/7b1b9829a2df4785bafcea1ad74f8a47

モーダルウィンドウの削除ボタンをクリック
https://gyazo.com/eb85c49105b37ab8c43b279942667662

削除を確認
https://gyazo.com/301941174570086b7de7d843a77ae3af


・モーダルウィンドウの条件分岐が、現在ログイン中のユーザーかつ投稿者の場合の表示と、他ユーザーの表示を異なるようにした。

現在ログイン中のユーザーかつ投稿者の場合の表示
https://gyazo.com/eb85c49105b37ab8c43b279942667662

他ユーザーの表示
https://gyazo.com/eef9dd17e4afe0f03323c0be736e6e02