### PR TITLE
Post video branch

### DIFF
--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/follows.coffee
+++ b/app/assets/javascripts/follows.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/images.js
+++ b/app/assets/javascripts/images.js
@@ -2,11 +2,26 @@ $(document).on('turbolinks:load', function() {
   $(function(){
   
     //プレビューのhtmlを定義
-    function buildHTML(count) {
+    // プレビュー表示がimageのとき
+    function buildHTML_img(count) {
       var html = `<div class="product-image" id="preview-box__${count}">
                     <div class="product-image__content">
                       <div class="product-image__content--icon">
                         <img src="" width="95" height="116">
+                      </div>
+                    </div>
+                    <div class="product-image__operetion">
+                      <div class="product-image__operetion--delete" id="delete_btn_${count}">削除</div>
+                    </div>
+                  </div>`
+      $('.image-box').before(html);
+    }
+    // プレビュー表示がvideoのとき
+    function buildHTML_video(count) {
+      var html = `<div class="product-image" id="preview-box__${count}">
+                    <div class="product-image__content">
+                      <div class="product-image__content--icon">
+                        <video src="" width="95" height="116">
                       </div>
                     </div>
                     <div class="product-image__operetion">
@@ -52,14 +67,20 @@ $(document).on('turbolinks:load', function() {
         var image = this.result;
         //プレビューが元々なかった場合はhtmlを追加
         if ($(`#preview-box__${id}`).length == 0) {
-          var html = buildHTML(id);
+          // fileの拡張子を判別( imageかどうか )
+          if (file.name.match(/\.(jpg|jpeg|png|gif)$/)) {
+            var html = buildHTML_img(id);
+          } else {
+            var html = buildHTML_video(id);
+          }
           //labelの直前のプレビュー群にプレビューを追加
           var prevContent = $('.image-content').prev();
           $(prevContent).append(html);
         }
         //イメージを追加
         $(`#preview-box__${id} img`).attr('src', `${image}`);
-  
+        $(`#preview-box__${id} video`).attr('src', `${image}`);
+
         //プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す=============
         if ($(`#post_images_attributes_${id}__destroy`)){
           $(`#post_images_attributes_${id}__destroy`).prop('checked',false);

--- a/app/assets/javascripts/peoples.coffee
+++ b/app/assets/javascripts/peoples.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/posts.coffee
+++ b/app/assets/javascripts/posts.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/tags.coffee
+++ b/app/assets/javascripts/tags.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -532,7 +532,6 @@
         margin: 0 auto;
         display: flex;
         &__image {
-          margin: 5px 0;
         }
         &__side {
           &__header {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,6 +24,7 @@ class PostsController < ApplicationController
   end
   
   def create
+    @user = User.find(current_user.id)
     @post = Post.new(post_params)
     if @post.save
       redirect_to root_path

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -35,6 +35,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   # version :thumb do
     # process resize_to_filt: [300, 300]
   # end
+  version :thumb, if: :is_thumb?
+
   version :thumb do
     process resize_to_fit: [500, 500]
   end
@@ -50,4 +52,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+
+  private
+  def is_thumb? image
+    image.content_type.include?("image/")
+  end
 end

--- a/app/views/exhibitions/_post-show.html.haml
+++ b/app/views/exhibitions/_post-show.html.haml
@@ -2,7 +2,10 @@
   .modal-content
     .post-show
       .post-show__image
-        = image_tag @post.images.first.image.url, class: "post-show__image__contents", size: "450"
+        - if @post.images.first.image.file.content_type.include?('image/')
+          = image_tag @post.images.first.image.url, class: "post-show__image__contents", size: "450"
+        - else
+          = video_tag @post.images.first.image.url, class: "post-show__image__contents", size: "450", controls: true, loop: true
       .post-show__side
         .show-side-header
           .show-side-header__icon

--- a/app/views/exhibitions/save_post.html.haml
+++ b/app/views/exhibitions/save_post.html.haml
@@ -32,7 +32,10 @@
             .black-back
               .show-main-post
                 =link_to post_show_exhibition_path(id: post.id), remote: true do
-                  =image_tag post.images[0].image.url, class: "show-main-post__image"
+                  - if post.images.first.image.file.content_type.include?('image/')
+                    = image_tag post.images.first.image.url, class: "show-main-post__image"
+                  - else
+                    = video_tag post.images.first.image.url, class: "show-main-post__image"
                 .show-main-post__inner
                   .show-main-details
                     .show-main-details__hearts

--- a/app/views/exhibitions/show.html.haml
+++ b/app/views/exhibitions/show.html.haml
@@ -35,7 +35,10 @@
             .black-back
               .show-main-post
                 =link_to post_show_exhibition_path(id: post.id), remote: true do
-                  =image_tag post.images[0].image.url, class: "show-main-post__image"
+                  - if post.images.first.image.file.content_type.include?('image/')
+                    = image_tag post.images.first.image.url, class: "show-main-post__image"
+                  - else
+                    = video_tag post.images.first.image.url, class: "show-main-post__image"
                 .show-main-post__inner
                   .show-main-details
                     .show-main-details__hearts

--- a/app/views/posts/_posts-image.html.haml
+++ b/app/views/posts/_posts-image.html.haml
@@ -16,7 +16,10 @@
             = post.user.nickname
   %span.mainber__images
     =link_to post_path(post) do
-      = image_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614"
+      - if post.images.first.image.file.content_type.include?('image/')
+        = image_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614"
+      - else
+        = video_tag post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "614", controls: true, loop: true
   %section.mainber__icon
     %span.mainber__icon__heart
       = render partial: 'likes/like', locals: { post: post }

--- a/app/views/posts/_show-main.html.haml
+++ b/app/views/posts/_show-main.html.haml
@@ -3,7 +3,10 @@
     .posts__show__main__body
       .posts__show__main__body__contents
         .posts__show__main__body__contents__image
-          = image_tag @post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "436x436"
+          - if @post.images.first.image.file.content_type.include?('image/')
+            = image_tag @post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "448"
+          - else
+            = video_tag @post.images.first.image.url, class: "main-new-arrival__product--image--first slick", size: "448", controls: true, loop: true
         .posts__show__main__body__contents__side
           .posts__show__main__body__contents__side__header
             .posts__show__main__body__contents__side__header__icon

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -26,7 +26,7 @@
             またはクリックしてファイルをアップロード 
 
           = f.fields_for :images do |i|
-            = i.file_field :image, class: "image-field"
+            = i.file_field :image, accept: "image/jpeg,image/gif,image/png,video/mp4,video/.webm,video/.ogv", class: "image-field"
             %input{class:"image-field", type: "file", name: "post[images_attributes][1][image]", id: "post_images_attributes_1_image"}
             %input{class:"image-field", type: "file", name: "post[images_attributes][2][image]", id: "post_images_attributes_2_image"}
             %input{class:"image-field", type: "file", name: "post[images_attributes][3][image]", id: "post_images_attributes_3_image"}


### PR DESCRIPTION
## What
- coffee_fileの削除
- 投稿詳細ページのcss微調整
- image_uploderの編集( thumbをimageのみ作成するよう設定 )
- imageとvideoで表示方法を変更( topページ, 投稿詳細ページ, プロフィールページ, プロフィールページの投稿詳細モーダル )
- 新規投稿ページのプレビューをvideoの時は " video_tag " で表示するよう設定

## Why
- 新規投稿で動画も画像と一緒に投稿できるようにするため。
- トップページ、詳細ページなどで投稿動画を閲覧できるようにするため。